### PR TITLE
fix: organize imports when template contains <style> or <script>

### DIFF
--- a/.changeset/strip-style-and-script-from-tsx.md
+++ b/.changeset/strip-style-and-script-from-tsx.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-astro-organize-imports": patch
+---
+
+Fix imports silently not being organized when the template contains a `<style>` tag (or a `<script>` tag whose body isn't valid TSX). `<style>`/`<script>` elements are now stripped from the synthetic TSX passed to TypeScript's language service, so frontmatter imports are organized regardless of template contents (#221).

--- a/src/organize-imports/organize-imports.ts
+++ b/src/organize-imports/organize-imports.ts
@@ -5,6 +5,7 @@ import {
   TSLINT_DISABLE_ORDERED_IMPORTS_COMMENT,
 } from './constants'
 import { getLanguageService } from './get-language-service'
+import { stripStyleAndScriptElements } from './strip-style-and-script'
 
 const FILE_PATH = 'file.tsx'
 
@@ -59,8 +60,16 @@ function organize(code: string, mode: OrganizeImportsMode) {
   const frontmatter = match[2]
   const template = code.slice(match[0].length)
 
+  const sanitizedTemplate = stripStyleAndScriptElements(code).slice(
+    match[0].length,
+  )
+
   const tsCode =
-    frontmatter + TEMPLATE_BOUNDARY + newline + template + TEMPLATE_WRAPPER_END
+    frontmatter +
+    TEMPLATE_BOUNDARY +
+    newline +
+    sanitizedTemplate +
+    TEMPLATE_WRAPPER_END
   const organized = organizeCode(tsCode, mode)
   const boundaryIdx = organized.indexOf(TEMPLATE_BOUNDARY_MARKER)
   const organizedFrontmatter = preserveSemicolonStyle(

--- a/src/organize-imports/strip-style-and-script.ts
+++ b/src/organize-imports/strip-style-and-script.ts
@@ -1,0 +1,57 @@
+import { parse } from '@astrojs/compiler/sync'
+import type { Node } from '@astrojs/compiler/types'
+import { substringByBytes } from './substring'
+
+/**
+ * Remove `<style>` and `<script>` elements from Astro code.
+ *
+ * The TypeScript language service's `organizeImports` requires the wrapped
+ * template to be valid TSX. Inline CSS (e.g. `div { color: red }`) trips the
+ * TSX parser on the unmatched braces, and arbitrary script bodies can also
+ * fail to parse. When parsing fails, the language service silently returns no
+ * edits, leaving frontmatter imports unsorted (issue #221).
+ *
+ * Both element types are safe to drop: their contents do not reference
+ * frontmatter import bindings (script tags run as separate modules and styles
+ * are CSS), so removal cannot mark a frontmatter import as unused.
+ */
+export function stripStyleAndScriptElements(code: string): string {
+  const { ast } = parse(code, { position: true })
+
+  const ranges: Array<{ start: number; end: number }> = []
+
+  function walk(node: Node) {
+    if (
+      node.type === 'element' &&
+      (node.name === 'style' || node.name === 'script')
+    ) {
+      if (node.position?.start && node.position.end) {
+        ranges.push({
+          start: node.position.start.offset,
+          end: node.position.end.offset,
+        })
+      }
+      return
+    }
+
+    if ('children' in node && Array.isArray(node.children)) {
+      for (const child of node.children) {
+        walk(child)
+      }
+    }
+  }
+
+  walk(ast)
+
+  if (ranges.length === 0) {
+    return code
+  }
+
+  ranges.sort((a, b) => b.start - a.start)
+
+  let result = code
+  for (const { start, end } of ranges) {
+    result = substringByBytes(result, 0, start) + substringByBytes(result, end)
+  }
+  return result
+}

--- a/tests/fixtures/style-and-script-tags/expected.astro
+++ b/tests/fixtures/style-and-script-tags/expected.astro
@@ -1,0 +1,20 @@
+---
+import Bar from './Bar.astro'
+import Foo from './Foo.astro'
+---
+
+<Foo>
+  <Bar />
+</Foo>
+
+<script>
+  import { bar } from 'bar'
+import { foo } from 'foo'
+  console.log(foo, bar)
+</script>
+
+<style>
+  div {
+    color: red;
+  }
+</style>

--- a/tests/fixtures/style-and-script-tags/input.astro
+++ b/tests/fixtures/style-and-script-tags/input.astro
@@ -1,0 +1,20 @@
+---
+import Foo from './Foo.astro'
+import Bar from './Bar.astro'
+---
+
+<Foo>
+  <Bar />
+</Foo>
+
+<script>
+  import { foo } from 'foo'
+  import { bar } from 'bar'
+  console.log(foo, bar)
+</script>
+
+<style>
+  div {
+    color: red;
+  }
+</style>

--- a/tests/fixtures/style-tag-with-attributes/expected.astro
+++ b/tests/fixtures/style-tag-with-attributes/expected.astro
@@ -1,0 +1,22 @@
+---
+import Bar from './Bar.astro'
+import Foo from './Foo.astro'
+---
+
+<Foo>
+  <Bar />
+</Foo>
+
+<style is:global>
+  body {
+    margin: 0;
+  }
+</style>
+
+<style lang="scss">
+  .nested {
+    & .child {
+      color: blue;
+    }
+  }
+</style>

--- a/tests/fixtures/style-tag-with-attributes/input.astro
+++ b/tests/fixtures/style-tag-with-attributes/input.astro
@@ -1,0 +1,22 @@
+---
+import Foo from './Foo.astro'
+import Bar from './Bar.astro'
+---
+
+<Foo>
+  <Bar />
+</Foo>
+
+<style is:global>
+  body {
+    margin: 0;
+  }
+</style>
+
+<style lang="scss">
+  .nested {
+    & .child {
+      color: blue;
+    }
+  }
+</style>

--- a/tests/fixtures/style-tag/expected.astro
+++ b/tests/fixtures/style-tag/expected.astro
@@ -1,0 +1,13 @@
+---
+import Alpha from './components/Alpha.astro'
+import Beta from './components/Beta.astro'
+---
+
+<Alpha />
+<Beta />
+
+<style>
+  div {
+    color: red;
+  }
+</style>

--- a/tests/fixtures/style-tag/input.astro
+++ b/tests/fixtures/style-tag/input.astro
@@ -1,0 +1,13 @@
+---
+import Beta from './components/Beta.astro'
+import Alpha from './components/Alpha.astro'
+---
+
+<Alpha />
+<Beta />
+
+<style>
+  div {
+    color: red;
+  }
+</style>

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -42,6 +42,18 @@ const tests = [
     fixtureDir: 'script-tags',
   },
   {
+    name: 'style tag in template',
+    fixtureDir: 'style-tag',
+  },
+  {
+    name: 'style tag with attributes (is:global, lang)',
+    fixtureDir: 'style-tag-with-attributes',
+  },
+  {
+    name: 'style and script tags in template',
+    fixtureDir: 'style-and-script-tags',
+  },
+  {
     name: 'ignore organize imports inside script tags',
     fixtureDir: 'ignore-organize-imports-in-script-tags',
     options: {


### PR DESCRIPTION
## Summary

Fixes #221.

When an `.astro` file's template contains a `<style>` tag (or a `<script>` whose body isn't valid TSX), `organizeImports` silently returned the file unchanged. The plugin builds a synthetic TSX wrapper around the template to feed TypeScript's language service, and the CSS braces inside `<style>` (e.g. `div { color: red; }`) caused that wrapper to fail TSX parsing — TS then returned no edits and the outer `try/catch` never fired.

This change strips `<style>` and `<script>` element ranges from the template before constructing the TSX, using the existing `@astrojs/compiler/sync` AST that the plugin already relies on for script-tag handling. The original template is still emitted verbatim in the output, so styles and scripts are preserved untouched. Both element types are safe to drop because their bodies don't reference frontmatter import bindings (`<script>` runs as a separate module, `<style>` is CSS).

## Changes

- `src/organize-imports/strip-style-and-script.ts` — new helper that walks the AST and removes `<style>`/`<script>` byte ranges
- `src/organize-imports/organize-imports.ts` — feeds the sanitized template (not the original) into the TSX wrapper
- 3 new fixture tests:
  - `style-tag` — the canonical case from the issue
  - `style-tag-with-attributes` — `<style is:global>` and `<style lang="scss">` with nested SCSS
  - `style-and-script-tags` — both elements present; verifies existing script-tag import organization still runs
- Changeset (patch)

## Test plan

- [x] New `style-tag` fixture fails on `main` (reproduces the bug) and passes with the fix
- [x] All 18 fixture tests pass (`npm test`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] Verified `<style is:global>`, `<style lang="scss">`, and combined style+script cases