### PR TITLE
Emit declaration file during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "node scripts/build.mjs",
+    "build": "node scripts/build.mjs && tsc -p tsconfig.build.json",
     "clean": "rimraf dist",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a declaration-only TypeScript build config
- run declaration emit after the existing esbuild bundle step so dist/index.d.ts is published with the package

## Verification
- npm run build
- npm run typecheck
- npm pack --ignore-scripts, install the local tarball into a clean TypeScript project, and run npx tsc --noEmit

The current published package declares types: dist/index.d.ts, but npm pack for 0.4.12 only includes dist/index.mjs. A clean TypeScript import therefore reports TS7016.