### PR TITLE
fix: keep the fallback printer so standalone usage works

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
-import type { Parser, Printer, SupportOption } from 'prettier'
+import type {
+  AstPath,
+  Doc,
+  Options,
+  Parser,
+  ParserOptions,
+  Printer,
+  SupportOption,
+} from 'prettier'
 import { OrganizeImportsMode } from 'typescript'
 import {
   organizeImports,
@@ -32,8 +40,17 @@ export const parsers: Record<string, Parser> = {
       result = options.astroOrganizeImportsInScriptTags
         ? organizeImportsInScriptTags(result, options)
         : result
-      const preprocessed = originalParser.preprocess?.(result, options)
-      result = typeof preprocessed === 'string' ? preprocessed : result
+      // `unknown` because Prettier's own type for this differs across 3.x.
+      const preprocessed: unknown = originalParser.preprocess?.(result, options)
+      if (preprocessed instanceof Promise) {
+        throw new Error(
+          'A compatible plugin returned an async `preprocess`, which cannot be ' +
+            'awaited here without breaking Prettier 3.6 (#223).',
+        )
+      }
+      if (typeof preprocessed === 'string') {
+        result = preprocessed
+      }
       result = organizeImports(result, options.astroOrganizeImportsMode)
       return result
     },
@@ -46,7 +63,33 @@ export const parsers: Record<string, Parser> = {
 }
 
 export const printers: Record<string, Printer> = {
-  astro: plugin.printer as Printer,
+  astro: {
+    print(path: AstPath, opts: ParserOptions, print: (path: AstPath) => Doc) {
+      const original = plugin.originalPrinter(opts)
+
+      if (original.print) {
+        return original.print(path, opts, print)
+      }
+
+      const { node } = path
+
+      if (typeof node === 'string') {
+        return node
+      }
+
+      return node.value
+    },
+
+    embed(path: AstPath, options: Options) {
+      const original = plugin.originalPrinter(options)
+
+      if (original.embed) {
+        return original.embed(path, options)
+      }
+
+      return null
+    },
+  },
 }
 
 export const options: Record<keyof PluginOptions, SupportOption> = {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -46,7 +46,6 @@ export async function loadPlugin() {
   const compatible = await loadCompatiblePlugins()
 
   const baseParser = base.parsers?.astro ? { ...base.parsers.astro } : {}
-  const basePrinter = base.printers?.astro ? { ...base.printers.astro } : {}
 
   function maybeResolve(name: string) {
     try {
@@ -101,7 +100,6 @@ export async function loadPlugin() {
 
   return {
     parser: baseParser,
-    printer: basePrinter,
 
     originalParser(options: Options): Partial<Parser> {
       if (!options.plugins) {

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -107,7 +107,8 @@ describe('format', () => {
     })
   }
 
-  test('preprocess returns a string synchronously', () => {
+  // Prettier 3.6.x does not await this hook (#223).
+  test('preprocess stays synchronous, so no Promise reaches the parser', () => {
     const { input } = readFixture('with-astro-plugin-no-imports')
     const actual = parsers.astro.preprocess?.(input, {
       astroOrganizeImportsInScriptTags: true,


### PR DESCRIPTION
#225 replaced `printers.astro`, which breaks using this plugin without
`prettier-plugin-astro` — the setup the README recommends:

```
TypeError: printer.print is not a function
```

That block is the fallback from #195, so it stays. The rest of #225 is
untouched.