### PR TITLE
fix: keep define:vars bindings when stripping style and script

### DIFF
--- a/src/organize-imports/strip-style-and-script.ts
+++ b/src/organize-imports/strip-style-and-script.ts
@@ -3,22 +3,15 @@ import type { Node } from '@astrojs/compiler/types'
 import { substringByBytes } from './substring'
 
 /**
- * Remove `<style>` and `<script>` elements from Astro code.
- *
- * The TypeScript language service's `organizeImports` requires the wrapped
- * template to be valid TSX. Inline CSS (e.g. `div { color: red }`) trips the
- * TSX parser on the unmatched braces, and arbitrary script bodies can also
- * fail to parse. When parsing fails, the language service silently returns no
- * edits, leaving frontmatter imports unsorted (issue #221).
- *
- * Both element types are safe to drop: their contents do not reference
- * frontmatter import bindings (script tags run as separate modules and styles
- * are CSS), so removal cannot mark a frontmatter import as unused.
+ * Remove `<style>` and `<script>` elements so their bodies cannot break the
+ * TSX the language service parses -- a parse failure silently returns no edits
+ * at all (#221). Their `define:vars` expression is re-emitted on its own,
+ * because it is the one place these elements reference a frontmatter binding.
  */
 export function stripStyleAndScriptElements(code: string): string {
   const { ast } = parse(code, { position: true })
 
-  const ranges: Array<{ start: number; end: number }> = []
+  const edits: Array<{ start: number; end: number; replacement: string }> = []
 
   function walk(node: Node) {
     if (
@@ -26,9 +19,17 @@ export function stripStyleAndScriptElements(code: string): string {
       (node.name === 'style' || node.name === 'script')
     ) {
       if (node.position?.start && node.position.end) {
-        ranges.push({
+        const defineVars = node.attributes?.find(
+          (attribute) =>
+            attribute.name === 'define:vars' &&
+            attribute.kind === 'expression' &&
+            attribute.value,
+        )
+
+        edits.push({
           start: node.position.start.offset,
           end: node.position.end.offset,
+          replacement: defineVars ? `{(${defineVars.value})}` : '',
         })
       }
       return
@@ -43,15 +44,19 @@ export function stripStyleAndScriptElements(code: string): string {
 
   walk(ast)
 
-  if (ranges.length === 0) {
+  if (edits.length === 0) {
     return code
   }
 
-  ranges.sort((a, b) => b.start - a.start)
+  // Apply back to front so the earlier offsets stay valid.
+  edits.sort((a, b) => b.start - a.start)
 
   let result = code
-  for (const { start, end } of ranges) {
-    result = substringByBytes(result, 0, start) + substringByBytes(result, end)
+  for (const { start, end, replacement } of edits) {
+    result =
+      substringByBytes(result, 0, start) +
+      replacement +
+      substringByBytes(result, end)
   }
   return result
 }

--- a/tests/fixtures/script-define-vars/expected.astro
+++ b/tests/fixtures/script-define-vars/expected.astro
@@ -1,0 +1,10 @@
+---
+import { other } from './other'
+import { message } from './strings'
+---
+
+<p>{other}</p>
+
+<script define:vars={{ message }}>
+  console.log(message)
+</script>

--- a/tests/fixtures/script-define-vars/input.astro
+++ b/tests/fixtures/script-define-vars/input.astro
@@ -1,0 +1,10 @@
+---
+import { message } from './strings'
+import { other } from './other'
+---
+
+<p>{other}</p>
+
+<script define:vars={{ message }}>
+  console.log(message)
+</script>

--- a/tests/fixtures/style-define-vars-with-attributes/expected.astro
+++ b/tests/fixtures/style-define-vars-with-attributes/expected.astro
@@ -1,0 +1,12 @@
+---
+import { greeting } from './strings'
+import { textColor } from './theme'
+---
+
+<h1>{greeting}</h1>
+
+<style lang=scss define:vars={{ textColor }}>
+  h1 {
+    color: var(--textColor);
+  }
+</style>

--- a/tests/fixtures/style-define-vars-with-attributes/input.astro
+++ b/tests/fixtures/style-define-vars-with-attributes/input.astro
@@ -1,0 +1,12 @@
+---
+import { textColor } from './theme'
+import { greeting } from './strings'
+---
+
+<h1>{greeting}</h1>
+
+<style lang=scss define:vars={{ textColor }}>
+  h1 {
+    color: var(--textColor);
+  }
+</style>

--- a/tests/fixtures/style-define-vars/expected.astro
+++ b/tests/fixtures/style-define-vars/expected.astro
@@ -1,0 +1,12 @@
+---
+import { greeting } from './strings'
+import { textColor } from './theme'
+---
+
+<h1>{greeting}</h1>
+
+<style define:vars={{ textColor }}>
+  h1 {
+    color: var(--textColor);
+  }
+</style>

--- a/tests/fixtures/style-define-vars/input.astro
+++ b/tests/fixtures/style-define-vars/input.astro
@@ -1,0 +1,12 @@
+---
+import { textColor } from './theme'
+import { greeting } from './strings'
+---
+
+<h1>{greeting}</h1>
+
+<style define:vars={{ textColor }}>
+  h1 {
+    color: var(--textColor);
+  }
+</style>

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -55,6 +55,18 @@ const tests = [
     fixtureDir: 'style-and-script-tags',
   },
   {
+    name: 'keeps imports used only by define:vars',
+    fixtureDir: 'style-define-vars',
+  },
+  {
+    name: 'keeps imports used only by define:vars in a script tag',
+    fixtureDir: 'script-define-vars',
+  },
+  {
+    name: 'keeps define:vars imports when the tag carries other attributes',
+    fixtureDir: 'style-define-vars-with-attributes',
+  },
+  {
     name: 'ignore organize imports inside script tags',
     fixtureDir: 'ignore-organize-imports-in-script-tags',
     options: {


### PR DESCRIPTION
#222 strips whole `<style>`/`<script>` elements. That also removes
`define:vars={{ foo }}`, so `foo` looks unused and its import gets deleted —
the component then breaks at build time.

The element is still dropped, but that expression is re-emitted:

```
<style define:vars={{ foo }}>…</style>  →  {({ foo })}
```

3 fixtures added, all of which fail without this.