### PR TITLE
chore: add the changeset #224 was missing

### DIFF
--- a/.changeset/emit-declaration-file.md
+++ b/.changeset/emit-declaration-file.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-astro-organize-imports": patch
+---
+
+Emit `dist/index.d.ts` during build so the published package ships the type declarations it already advertises via the `types` field (previously consumers got `TS7016`)


### PR DESCRIPTION
#224 landed without a changeset, so it would ship in 0.4.13 with no
changelog entry and no credit for its author.