### PR TITLE
ci: cover standalone usage and every supported Prettier line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,23 @@ jobs:
       - run: npm run format:check
       - run: npm run lint
       - run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.0 is the peerDependency floor. 3.6 does not await the parser's
+        # `preprocess` hook and 3.7 does, so both sides of that line (#223).
+        prettier: ['3.0', '3.6', '3.7', '3.8']
+    name: test (prettier ${{ matrix.prettier }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+      - run: npm install --ignore-scripts
+      - run: npm install --no-save --ignore-scripts prettier@${{ matrix.prettier }}
       - run: npm test
+      - run: npm run test:standalone

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,5 +13,15 @@ export default [
         '@typescript-eslint/no-empty-object-type': 'off',
       },
     },
+    {
+      // Build and test scripts run in Node, outside the typed `src` config.
+      files: ['scripts/**/*.mjs'],
+      languageOptions: {
+        globals: {
+          console: 'readonly',
+          process: 'readonly',
+        },
+      },
+    },
   ),
 ]

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepare": "lefthook install",
     "release": "npm run clean && npm run build && changeset publish",
     "test": "npm run build && vitest --run",
+    "test:standalone": "npm run build && node scripts/smoke-standalone.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/scripts/smoke-standalone.mjs
+++ b/scripts/smoke-standalone.mjs
@@ -1,0 +1,115 @@
+/**
+ * The configuration the README recommends: this plugin on its own, without
+ * `prettier-plugin-astro`. The normal suite cannot cover it, because that
+ * package is always present here as a devDependency.
+ *
+ * The temporary project has to live outside the repository, or Node resolves
+ * the package we are deliberately leaving out from our own node_modules.
+ */
+import { spawnSync } from 'child_process'
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const dir = mkdtempSync(
+  path.join(tmpdir(), 'astro-organize-imports-standalone-'),
+)
+
+try {
+  const nodeModules = path.join(dir, 'node_modules')
+  mkdirSync(path.join(nodeModules, '@astrojs'), { recursive: true })
+
+  // The bundle's only external runtime dependency.
+  symlinkSync(
+    path.join(repo, 'node_modules/@astrojs/compiler'),
+    path.join(nodeModules, '@astrojs/compiler'),
+    'dir',
+  )
+
+  const pkgDir = path.join(
+    nodeModules,
+    'prettier-plugin-astro-organize-imports',
+  )
+  mkdirSync(path.join(pkgDir, 'dist'), { recursive: true })
+  writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({
+      name: 'prettier-plugin-astro-organize-imports',
+      version: '0.0.0-standalone-smoke',
+      type: 'module',
+      main: 'dist/index.mjs',
+      exports: { '.': './dist/index.mjs' },
+    }),
+  )
+  copyFileSync(
+    path.join(repo, 'dist/index.mjs'),
+    path.join(pkgDir, 'dist/index.mjs'),
+  )
+
+  const input = [
+    '---',
+    "import Beta from './Beta.astro'",
+    "import Alpha from './Alpha.astro'",
+    '---',
+    '',
+    '<Alpha />',
+    '<Beta />',
+    '',
+  ].join('\n')
+
+  const expected = [
+    '---',
+    "import Alpha from './Alpha.astro'",
+    "import Beta from './Beta.astro'",
+    '---',
+    '',
+    '<Alpha />',
+    '<Beta />',
+  ].join('\n')
+
+  writeFileSync(
+    path.join(dir, 'run.mjs'),
+    [
+      `import prettier from ${JSON.stringify(path.join(repo, 'node_modules/prettier/index.mjs'))}`,
+      `const input = ${JSON.stringify(input)}`,
+      `const out = await prettier.format(input, {`,
+      `  semi: false,`,
+      `  singleQuote: true,`,
+      `  printWidth: 9999,`,
+      `  parser: 'astro',`,
+      `  plugins: [${JSON.stringify(path.join(pkgDir, 'dist/index.mjs'))}],`,
+      `})`,
+      `process.stdout.write(out)`,
+    ].join('\n'),
+  )
+
+  const result = spawnSync(process.execPath, [path.join(dir, 'run.mjs')], {
+    cwd: dir,
+    encoding: 'utf8',
+  })
+
+  if (result.status !== 0) {
+    console.error(result.stderr)
+    throw new Error('formatting failed without prettier-plugin-astro installed')
+  }
+
+  const actual = result.stdout.trim()
+  if (actual !== expected) {
+    console.error('--- expected ---\n' + expected)
+    console.error('--- actual ---\n' + actual)
+    throw new Error('standalone output did not match')
+  }
+
+  console.log('standalone smoke test passed')
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}


### PR DESCRIPTION
Two gaps that let the above through:

- CI only ran the one Prettier pinned in devDependencies. #223 only
  reproduces on 3.6.
- `prettier-plugin-astro` is always installed here, so nothing exercised
  the README's standalone setup.

Adds a Prettier matrix (3.0 / 3.6 / 3.7 / 3.8) and a standalone smoke test.

Merge after #227 — the smoke test fails without it.