### PR TITLE
ci: publish through npm trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,26 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
       - run: npm install --ignore-scripts
       - run: npm run format:check
       - run: npm run lint
       - run: npm run typecheck
+      - name: Lint workflows
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color
 
   test:
     runs-on: ubuntu-latest
@@ -31,10 +38,10 @@ jobs:
         prettier: ['3.0', '3.6', '3.7', '3.8']
     name: test (prettier ${{ matrix.prettier }})
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
       - run: npm install --ignore-scripts
       - run: npm install --no-save --ignore-scripts prettier@${{ matrix.prettier }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,21 +7,27 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+  # Lets npm exchange a short-lived OIDC token instead of a stored NPM_TOKEN.
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      # Node 24 ships npm 11, the floor for trusted publishing. No cache here:
+      # this is the job that publishes.
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          cache: 'npm'
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
       - run: npm install --ignore-scripts
-      - id: changesets
-        uses: changesets/action@v1
+      - uses: changesets/action@v1
         with:
           publish: npm run release
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Publish through npm trusted publishing instead of a stored `NPM_TOKEN`, which
expired and broke the 0.4.13 release.

Also updates the actions and adds actionlint to `quality`.